### PR TITLE
Change generate resource to scaffold

### DIFF
--- a/react_in_rails/devise.md
+++ b/react_in_rails/devise.md
@@ -43,7 +43,7 @@ Devise will create some helpers to use inside your controllers and views. To set
 ### Add a resource
 
 ```
-- $ rails generate resource Bike brand:string model_year:integer model:string user_id:integer
+- $ rails generate scaffold Bike brand:string model_year:integer model:string user_id:integer
 - $ rails db:migrate
 ```
 


### PR DESCRIPTION
In Matt's talk https://www.youtube.com/watch?v=ypXAYSn4PqY at 20:11 he's using scaffold instead of resource. When following this guide, resource does not create views as shown in app > views > bikes (or appartments if you are trying to complete the challenge. This is referenced from these notes on Rails 5 https://sandeep45.github.io/redux/react/react-router/2016/08/23/notes-while-reading-rails5-guide.html